### PR TITLE
[IMP] csve_partner: allow more complex recordset"

### DIFF
--- a/csv_export_base/models/csv_export_base.py
+++ b/csv_export_base/models/csv_export_base.py
@@ -36,7 +36,12 @@ class BaseCSVExport(models.AbstractModel):
     start_date = fields.Date(string="Start Date", required=True)
     end_date = fields.Date(string="End Date", required=True)
 
+    def get_recordset(self):
+        """override this function for more complex record selection"""
+        return self.env[self._connector_model].search(self.get_domain())
+
     def get_domain(self):
+        """override this method to use simple domain on _model"""
         raise NotImplementedError
 
     def get_headers(self):
@@ -56,7 +61,7 @@ class BaseCSVExport(models.AbstractModel):
 
     @api.multi
     def get_headers_rows_array(self):
-        recordset = self.env[self._connector_model].search(self.get_domain())
+        recordset = self.get_recordset()
         _logger.info("fetching data for %s export" % self._connector_model)
         header = self.get_headers()
         rows = self.get_rows(recordset)


### PR DESCRIPTION
[task](https://gestion.coopiteasy.be/web?#id=6142&view_type=form&model=project.task&action=475&active_id=27)

**before**
In implementation exports, you can set an odoo domain to select data by overriding `get_domain`

**after**
If you need more complex query, you can now override `get_recordset`
