### PR TITLE
[REM] csv_export_partner: remove use of fax field

### DIFF
--- a/csv_export_partner/__manifest__.py
+++ b/csv_export_partner/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Export Partner CSV",
     "version": "12.0.1.0.0",
-    "depends": ["csv_export_base", "partner_firstname", "partner_fax"],
+    "depends": ["csv_export_base", "partner_firstname"],
     "author": "Coop IT Easy SCRLfs",
     "summary": "Export your partners as CSV flat files",
     "website": "https://coopiteasy.be",

--- a/csv_export_partner/models/csv_export_partner.py
+++ b/csv_export_partner/models/csv_export_partner.py
@@ -130,7 +130,7 @@ class PartnerCSVExport(models.TransientModel):
             lang,
             partner.mobile,
             partner.phone,
-            partner.fax,
+            "",  # dummy value for fax
             fiscal_position_code,
             partner.vat,
             iban,


### PR DESCRIPTION
[task](https://gestion.coopiteasy.be/web#id=7584&view_type=form&model=project.task)

*   leave fax column present for compatibility reasons, but use an empty string as value.
*   remove dependency on partner_fax module.