### PR TITLE
[12.0][FIX] negative price_tax for refunds

### DIFF
--- a/csv_export_invoice/models/csv_export_invoice.py
+++ b/csv_export_invoice/models/csv_export_invoice.py
@@ -63,6 +63,10 @@ class InvoiceCSVExport(models.TransientModel):
 
         tax_code = tax.export_code if tax else ""
 
+        price_tax_signed = line.price_tax
+        if invoice.type == "out_refund" or invoice.type == "in_refund":
+            price_tax_signed = -line.price_tax
+
         product_name = line.product_id.with_context(lang="fr_BE").name
 
         row = (
@@ -77,7 +81,7 @@ class InvoiceCSVExport(models.TransientModel):
             line.account_id.code,
             str(line.price_subtotal_signed),
             tax_code,
-            str(line.price_tax),
+            str(price_tax_signed),
             product_name,
             invoice.department_id.bob_code,
             invoice.location_id.bob_code,


### PR DESCRIPTION
Although the subtotal price is negative for refunds in csv exports, the price_tax is still positive. This PR computes a "signed" price tax based on the type of invoice. 

internal task : https://gestion.coopiteasy.be/web#id=12045&model=project.task&view_type=form&menu_id=

@robinkeunen for review